### PR TITLE
switch to ubuntu 20.04 lts

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -9,7 +9,7 @@
 # software components inside the image are under the respective
 # licenses chosen by their respective copyright holders.
 #
-FROM ubuntu:20.10
+FROM ubuntu:20.04
 MAINTAINER Thomas Weise <tweise@hfuu.edu.cn>
 
 ENV LANG=C.UTF-8


### PR DESCRIPTION
switches base image to ubuntu 20.04 lts as 20.10 is no longer in support.

working version: kjcain/docker-texlive-full:latest